### PR TITLE
feat: batch processed event

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ consumer.start();
 ## Events and logging
 
 SqsConsumer has an internal [EventEmitter](https://nodejs.org/api/events.html), you can subscribe for events like this:
+
 ```ts
 sqsConsumer.on(SqsConsumerEvents.messageProcessed, () => {
     // ...
@@ -159,6 +160,8 @@ It sends the following events:
 | started             | None             | Fires when the polling is started                                                   |
 | message-received    | `message`        | Fires when a message is received (one per each message, not per batch)              |
 | message-processed   | `message`        | Fires after the message is successfully processed and removed from the queue        |
+| batch-processed     | None             | Fires after the current batch of messages is processed.                             |
+| poll-ended          | None             | Fires after the polling cycle is ended. Useful for graceful shutdown.               |
 | stopped             | None             | Fires when the polling stops                                                        |
 | error               | `{err, message}` | Fires in case of processing error                                                   |
 | s3-payload-error    | `{err, message}` | Fires when an error ocurrs during downloading payload from s3                       |
@@ -173,6 +176,8 @@ enum SqsConsumerEvents {
     started = 'started',
     messageReceived = 'message-received',
     messageProcessed = 'message-processed',
+    batchProcessed = 'batch-processed',
+    pollEnded = 'poll-ended',
     stopped = 'stopped',
     error = 'error',
     s3PayloadError = 's3-payload-error',

--- a/tests/sns-sqs.spec.ts
+++ b/tests/sns-sqs.spec.ts
@@ -191,6 +191,8 @@ describe('sns-sqs-big-payload', () => {
                 const handlers = getEventHandlers();
                 sendMessage(message);
                 const [receivedMessage] = await receiveMessages(1, {}, handlers);
+                // trigger macrotask to call event handlers
+                await new Promise((res) => setTimeout(res));
                 expect(receivedMessage).toEqual(message);
 
                 // success
@@ -198,6 +200,8 @@ describe('sns-sqs-big-payload', () => {
                 expect(handlers[SqsConsumerEvents.messageReceived]).toBeCalled();
                 expect(handlers[SqsConsumerEvents.messageParsed]).toBeCalled();
                 expect(handlers[SqsConsumerEvents.messageProcessed]).toBeCalled();
+                expect(handlers[SqsConsumerEvents.batchProcessed]).toBeCalled();
+                expect(handlers[SqsConsumerEvents.pollEnded]).toBeCalled();
                 expect(handlers[SqsConsumerEvents.stopped]).toBeCalled();
                 // errors
                 expect(handlers[SqsConsumerEvents.error]).not.toBeCalled();


### PR DESCRIPTION
I need this event to do a graceful shutdown of the microservice. Basically I want to 2 things:
1. stop polling
2. wait for current batch to be processed

I can do the first part just by calling `stop` method.
The event I've added in this PR helps me with the second thing.
