### PR TITLE
feat: add messageSizeThreshold option to producers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         run: docker-compose up -d
 
       - name: wait for localstack
-        run: ./scripts/wait-for-url.js http://localhost:4575 && sleep 5
+        run: ./scripts/wait-for-url.js http://localhost:4566 && sleep 5
 
       - name: test
         run: yarn test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ version: '2.1'
 services:
     localstack:
         container_name: '${LOCALSTACK_DOCKER_NAME-localstack_main}'
-        image: localstack/localstack:0.10.7
+        image: localstack/localstack:0.12.4
         ports:
-            - '4567-4599:4567-4599'
+            - '4566:4566'
             - '${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}'
         environment:
             - SERVICES=${SERVICES- }


### PR DESCRIPTION
This option is available in the java version.
Can be used when the message contains attributes in addition to the payload, which also counts for the message size.