### PR TITLE
Introduce awslabs (SQS Extended / S3 overflow) compatibility optin option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ const sqsConsumer = SqsConsumer.create({
     handleMessage: async ({ payload }) => {
         // ...
     },
+    // Opt-in to enable compatibility with
+    // Amazon SQS Extended Client Java Library (and other compatible libraries).
+    // see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-s3-messages.html
+    extendedLibraryCompatibility: boolean;
 });
 
 // to subscribe for events
@@ -114,6 +118,16 @@ sqsConsumer.stop();
 ## Usage in lambda
 
 If you have a lambda function subscribed to sqs queue, you can use SqsConsumer in this case too. [This is a short guide.](./docs/usage-in-lambda.md)
+
+## Compatibility with libraries in other languages
+
+If you turn on `extendedLibraryCompatibility`, then the library will be compatible with:
+
+-   Amazon SQS Extended Client Library for Java (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-s3-messages.html)
+-   Boto3 Sqs Extended Client Lib for python (https://github.com/timothymugayi/boto3-sqs-extended-client-lib)
+-   other libraries that are compatible to the above
+
+Please be careful: This mode is not compatible with the standard mode due to differences in s3 payload.
 
 ## Credentials
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ const snsProducer = SnsProducer.create({
     region: 'us-east-1',
     // to enable sending large payloads (>256KiB) though S3
     largePayloadThoughS3: true,
+    // Opt-in to enable compatibility with
+    // Amazon SQS Extended Client Java Library (and other compatible libraries).
+    // see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-s3-messages.html
+    extendedLibraryCompatibility: boolean;
     s3EndpointUrl: '...',
 });
 
@@ -61,6 +65,10 @@ const sqsProducer = SqsProducer.create({
     region: 'us-east-1',
     // to enable sending large payloads (>256KiB) though S3
     largePayloadThoughS3: true,
+    // Opt-in to enable compatibility with
+    // Amazon SQS Extended Client Java Library (and other compatible libraries).
+    // see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-s3-messages.html
+    extendedLibraryCompatibility: boolean;
     s3Bucket: '...',
 });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.1'
 services:
     localstack:
         container_name: '${LOCALSTACK_DOCKER_NAME-localstack_main}'
-        image: localstack/localstack:0.12.4
+        image: localstack/localstack:0.12.5
         ports:
             - '4566:4566'
             - '${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}'

--- a/src/sns-producer.ts
+++ b/src/sns-producer.ts
@@ -1,6 +1,7 @@
 import * as aws from 'aws-sdk';
+import { PromiseResult } from 'aws-sdk/lib/request';
 import { v4 as uuid } from 'uuid';
-import { PayloadMeta, S3PayloadMeta } from './types';
+import { S3PayloadMeta } from './types';
 import {
     buildS3PayloadWithExtendedCompatibility,
     buildS3Payload,
@@ -76,11 +77,11 @@ export class SnsProducer {
         this.extendedLibraryCompatibility = options.extendedLibraryCompatibility;
     }
 
-    public static create(options: SnsProducerOptions) {
+    public static create(options: SnsProducerOptions): SnsProducer {
         return new SnsProducer(options);
     }
 
-    async publishJSON(message: object): Promise<PublishResult> {
+    async publishJSON(message: unknown): Promise<PublishResult> {
         const messageBody = JSON.stringify(message);
         const msgSize = Buffer.byteLength(messageBody, 'utf-8');
 
@@ -128,7 +129,10 @@ export class SnsProducer {
         };
     }
 
-    async publishS3Payload(s3PayloadMeta: S3PayloadMeta, msgSize: number) {
+    async publishS3Payload(
+        s3PayloadMeta: S3PayloadMeta,
+        msgSize: number
+    ): Promise<PromiseResult<aws.SNS.PublishResponse, aws.AWSError>> {
         const messageAttributes = this.extendedLibraryCompatibility
             ? createExtendedCompatibilityAttributeMap(msgSize)
             : {};

--- a/src/sns-producer.ts
+++ b/src/sns-producer.ts
@@ -21,7 +21,7 @@ export interface SnsProducerOptions {
     messageSizeThreshold?: number;
     // Opt-in to enable compatibility with
     // Amazon SQS Extended Client Java Library (and other compatible libraries)
-    extendedLibraryCompatibility: boolean;
+    extendedLibraryCompatibility?: boolean;
 }
 
 export interface PublishResult {

--- a/src/sqs-consumer.ts
+++ b/src/sqs-consumer.ts
@@ -20,7 +20,7 @@ export interface SqsConsumerOptions {
     transformMessageBody?(messageBody: any): any;
     // Opt-in to enable compatibility with
     // Amazon SQS Extended Client Java Library (and other compatible libraries)
-    extendedLibraryCompatibility: boolean;
+    extendedLibraryCompatibility?: boolean;
 }
 
 export interface ProcessingOptions {

--- a/src/sqs-consumer.ts
+++ b/src/sqs-consumer.ts
@@ -72,7 +72,7 @@ export class SqsConsumer {
                 endpoint: options.sqsEndpointUrl,
             });
         }
-        if (options.getPayloadFromS3 || options.getPayloadFromS3) {
+        if (options.getPayloadFromS3) {
             if (options.s3) {
                 this.s3 = options.s3;
             } else {

--- a/src/sqs-producer.ts
+++ b/src/sqs-producer.ts
@@ -24,7 +24,7 @@ export interface SqsProducerOptions {
     messageSizeThreshold?: number;
     // Opt-in to enable compatibility with
     // Amazon SQS Extended Client Java Library (and other compatible libraries)
-    extendedLibraryCompatibility: boolean;
+    extendedLibraryCompatibility?: boolean;
 }
 
 export interface SqsMessageOptions {

--- a/src/sqs-producer.ts
+++ b/src/sqs-producer.ts
@@ -1,6 +1,7 @@
 import * as aws from 'aws-sdk';
+import { PromiseResult } from 'aws-sdk/lib/request';
 import { v4 as uuid } from 'uuid';
-import { PayloadMeta, S3PayloadMeta } from './types';
+import { S3PayloadMeta } from './types';
 import {
     buildS3PayloadWithExtendedCompatibility,
     buildS3Payload,
@@ -75,11 +76,11 @@ export class SqsProducer {
         this.extendedLibraryCompatibility = options.extendedLibraryCompatibility;
     }
 
-    static create(options: SqsProducerOptions) {
+    static create(options: SqsProducerOptions): SqsProducer {
         return new SqsProducer(options);
     }
 
-    async sendJSON(message: object, options: SqsMessageOptions = {}): Promise<any> {
+    async sendJSON(message: unknown, options: SqsMessageOptions = {}): Promise<any> {
         const messageBody = JSON.stringify(message);
         const msgSize = Buffer.byteLength(messageBody, 'utf-8');
 
@@ -132,7 +133,11 @@ export class SqsProducer {
     // send a message into the queue with payload which is already in s3.
     // for example: can be used to resend an unmodified message received via this lib from a queue
     // into another queue without duplicating the s3 object
-    async sendS3Payload(s3PayloadMeta: S3PayloadMeta, msgSize: number, options: SqsMessageOptions = {}) {
+    async sendS3Payload(
+        s3PayloadMeta: S3PayloadMeta,
+        msgSize: number,
+        options: SqsMessageOptions = {}
+    ): Promise<PromiseResult<aws.SQS.SendMessageResult, aws.AWSError>> {
         const messageAttributes = this.extendedLibraryCompatibility
             ? createExtendedCompatibilityAttributeMap(msgSize)
             : {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,3 +8,8 @@ export interface S3PayloadMeta {
     Key: string;
     Location: string;
 }
+
+export interface SqsExtendedPayloadMeta {
+    s3BucketName: string;
+    s3Key: string;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,22 @@
+import { S3PayloadMeta, PayloadMeta, SqsExtendedPayloadMeta } from './types';
+
+export const SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE = 'SQSLargePayloadSize';
+
+export function createExtendedCompatibilityAttributeMap(msgSize: number) {
+    const result = {};
+    result[SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE] = { StringValue: '' + msgSize, DataType: 'Number' };
+    return result;
+}
+
+export function buildS3Payload(s3PayloadMeta: S3PayloadMeta) {
+    return JSON.stringify({
+        S3Payload: s3PayloadMeta,
+    } as PayloadMeta);
+}
+
+export function buildS3PayloadWithExtendedCompatibility(s3PayloadMeta: S3PayloadMeta) {
+    return JSON.stringify({
+        s3BucketName: s3PayloadMeta.Bucket,
+        s3Key: s3PayloadMeta.Key,
+    } as SqsExtendedPayloadMeta);
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,20 +1,24 @@
+import { MessageAttributeMap } from 'aws-sdk/clients/sns';
 import { S3PayloadMeta, PayloadMeta, SqsExtendedPayloadMeta } from './types';
 
 export const SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE = 'SQSLargePayloadSize';
 
-export function createExtendedCompatibilityAttributeMap(msgSize: number) {
+export function createExtendedCompatibilityAttributeMap(msgSize: number): MessageAttributeMap {
     const result = {};
-    result[SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE] = { StringValue: '' + msgSize, DataType: 'Number' };
+    result[SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE] = {
+        StringValue: '' + msgSize,
+        DataType: 'Number',
+    };
     return result;
 }
 
-export function buildS3Payload(s3PayloadMeta: S3PayloadMeta) {
+export function buildS3Payload(s3PayloadMeta: S3PayloadMeta): string {
     return JSON.stringify({
         S3Payload: s3PayloadMeta,
     } as PayloadMeta);
 }
 
-export function buildS3PayloadWithExtendedCompatibility(s3PayloadMeta: S3PayloadMeta) {
+export function buildS3PayloadWithExtendedCompatibility(s3PayloadMeta: S3PayloadMeta): string {
     return JSON.stringify({
         s3BucketName: s3PayloadMeta.Bucket,
         s3Key: s3PayloadMeta.Key,


### PR DESCRIPTION
see https://github.com/aspecto-io/sns-sqs-big-payload/issues/19

tests are green with localstack. node-only tests in our project involving this functionality are also green.
tested interoperability with other libraries in our dev environment. Kind of a hassle to write an e2e test for that, because it means importing a whole other language environment into the project, that's why I decided not to do it.

One suggestion for the future is the ability to extend the API to allow for more MessageAttributes being set on the publisher and also allow receiving them on the consumer. But I think that should be in a separate PR.

Let me know what you think