### PR TITLE
fix: use correct schema for extended lib compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ const snsProducer = SnsProducer.create({
     // Opt-in to enable compatibility with
     // Amazon SQS Extended Client Java Library (and other compatible libraries).
     // see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-s3-messages.html
-    extendedLibraryCompatibility: boolean;
+    extendedLibraryCompatibility: boolean,
     s3EndpointUrl: '...',
 });
 
@@ -68,7 +68,7 @@ const sqsProducer = SqsProducer.create({
     // Opt-in to enable compatibility with
     // Amazon SQS Extended Client Java Library (and other compatible libraries).
     // see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-s3-messages.html
-    extendedLibraryCompatibility: boolean;
+    extendedLibraryCompatibility: boolean,
     s3Bucket: '...',
 });
 
@@ -104,7 +104,7 @@ const sqsConsumer = SqsConsumer.create({
     // Opt-in to enable compatibility with
     // Amazon SQS Extended Client Java Library (and other compatible libraries).
     // see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-s3-messages.html
-    extendedLibraryCompatibility: boolean;
+    extendedLibraryCompatibility: boolean,
 });
 
 // to subscribe for events
@@ -181,19 +181,20 @@ sqsConsumer.on(SqsConsumerEvents.messageProcessed, () => {
 
 It sends the following events:
 
-| Event               | Params           | Description                                                                         |
-| ------------------- | ---------------- | ----------------------------------------------------------------------------------- |
-| started             | None             | Fires when the polling is started                                                   |
-| message-received    | `message`        | Fires when a message is received (one per each message, not per batch)              |
-| message-processed   | `message`        | Fires after the message is successfully processed and removed from the queue        |
-| batch-processed     | None             | Fires after the current batch of messages is processed.                             |
-| poll-ended          | None             | Fires after the polling cycle is ended. Useful for graceful shutdown.               |
-| stopped             | None             | Fires when the polling stops                                                        |
-| error               | `{err, message}` | Fires in case of processing error                                                   |
-| s3-payload-error    | `{err, message}` | Fires when an error occurs during downloading payload from s3                       |
-| processing-error    | `{err, message}` | Fires when an error occurs during processing (only inside `handleMessage` function) |
-| connection-error    | `err`            | Fires when a connection error occurs during polling (retriable)                     |
-| payload-parse-error | `err`            | Fires when a connection error occurs during parsing                                 |
+| Event                     | Params                 | Description                                                                         |
+| ------------------------- | ---------------------- | ----------------------------------------------------------------------------------- |
+| started                   | None                   | Fires when the polling is started                                                   |
+| message-received          | `message`              | Fires when a message is received (one per each message, not per batch)              |
+| message-processed         | `message`              | Fires after the message is successfully processed and removed from the queue        |
+| batch-processed           | None                   | Fires after the current batch of messages is processed.                             |
+| poll-ended                | None                   | Fires after the polling cycle is ended. Useful for graceful shutdown.               |
+| stopped                   | None                   | Fires when the polling stops                                                        |
+| error                     | `{err, message}`       | Fires in case of processing error                                                   |
+| s3-payload-error          | `{err, message}`       | Fires when an error occurs during downloading payload from s3                       |
+| s3-extended-payload-error | `{err, message}`       | Fires when a payload from s3 using extended compatibility is not in expected format |
+| processing-error          | `{err, message}`       | Fires when an error occurs during processing (only inside `handleMessage` function) |
+| connection-error          | `err`                  | Fires when a connection error occurs during polling (retriable)                     |
+| payload-parse-error       | `err`                  | Fires when a connection error occurs during parsing                                 |
 
 You can also use this enum if you're using TypeScript
 
@@ -207,6 +208,7 @@ enum SqsConsumerEvents {
     stopped = 'stopped',
     error = 'error',
     s3PayloadError = 's3-payload-error',
+    s3ExtendedPayloadError = 's3-extended-payload-error',
     processingError = 'processing-error',
     connectionError = 'connection-error',
     payloadParseError = 'payload-parse-error',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE = 'SQSLargePayloadSize';
+export const AMAZON_EXTENDED_CLIENT_PAYLOAD_OFFLOADING_REFERENCE = 'software.amazon.payloadoffloading.PayloadS3Pointer';

--- a/src/sns-producer.ts
+++ b/src/sns-producer.ts
@@ -87,7 +87,7 @@ export class SnsProducer {
 
         if ((msgSize > this.messageSizeThreshold && this.largePayloadThoughS3) || this.allPayloadThoughS3) {
             const payloadId = uuid();
-            const payloadKey = `${payloadId}.json`;
+            const payloadKey = this.extendedLibraryCompatibility ? payloadId : `${payloadId}.json`;
             const s3Response = await this.s3
                 .upload({
                     Bucket: this.s3Bucket,
@@ -131,7 +131,7 @@ export class SnsProducer {
 
     async publishS3Payload(
         s3PayloadMeta: S3PayloadMeta,
-        msgSize: number
+        msgSize?: number
     ): Promise<PromiseResult<aws.SNS.PublishResponse, aws.AWSError>> {
         const messageAttributes = this.extendedLibraryCompatibility
             ? createExtendedCompatibilityAttributeMap(msgSize)

--- a/src/sqs-consumer.ts
+++ b/src/sqs-consumer.ts
@@ -230,24 +230,24 @@ export class SqsConsumer {
         if (this.extendedLibraryCompatibility && attributes && attributes[SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE]) {
             const msgJson = s3Object as SqsExtendedPayloadMeta;
             if (!Array.isArray(msgJson) || msgJson.length !== 2) {
-                const errorMessage = 'Invalid message format, expected an array with 2 elements';
+                const err = new Error('Invalid message format, expected an array with 2 elements');
                 this.events.emit(SqsConsumerEvents.s3extendedPayloadError, {
-                    errorMessage,
+                    err,
                     message: s3Object,
                 });
-                throw new Error(errorMessage);
+                throw err;
             }
 
             const s3Key = msgJson[1]?.s3Key;
             const s3BucketName = msgJson[1]?.s3BucketName;
 
             if (!s3Key?.length || !s3BucketName?.length) {
-                const errorMessage = 'Invalid message format, s3Key and s3BucketName fields are required';
+                const err = new Error('Invalid message format, s3Key and s3BucketName fields are required');
                 this.events.emit(SqsConsumerEvents.s3extendedPayloadError, {
-                    errorMessage,
+                    err,
                     message: s3Object,
                 });
-                throw new Error(errorMessage);
+                throw err;
             }
 
             s3PayloadMeta = {

--- a/src/sqs-consumer.ts
+++ b/src/sqs-consumer.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events';
 import { Message, MessageBodyAttributeMap, ReceiveMessageRequest, ReceiveMessageResult } from 'aws-sdk/clients/sqs';
 import { AWSError } from 'aws-sdk';
 import { PayloadMeta, S3PayloadMeta, SqsExtendedPayloadMeta } from './types';
-import { SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE } from './util';
+import { SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE } from './constants';
 
 export interface SqsConsumerOptions {
     queueUrl: string;
@@ -38,6 +38,7 @@ export enum SqsConsumerEvents {
     pollEnded = 'poll-ended',
     error = 'error',
     s3PayloadError = 's3-payload-error',
+    s3extendedPayloadError = 's3-extended-payload-error',
     processingError = 'processing-error',
     connectionError = 'connection-error',
     payloadParseError = 'payload-parse-error',
@@ -172,7 +173,7 @@ export class SqsConsumer {
             }));
 
             const messagesToDelete = await this.handleBatch(messagesWithPayload);
-            if (messagesToDelete && messagesToDelete?.length) 
+            if (messagesToDelete && messagesToDelete?.length)
                 await this.deleteBatch(messagesToDelete);
             else if (messagesToDelete === undefined)
                 await this.deleteBatch(messages);
@@ -228,9 +229,30 @@ export class SqsConsumer {
         const s3Object: SqsExtendedPayloadMeta | PayloadMeta = JSON.parse(messageBody);
         if (this.extendedLibraryCompatibility && attributes && attributes[SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE]) {
             const msgJson = s3Object as SqsExtendedPayloadMeta;
+            if (!Array.isArray(msgJson) || msgJson.length !== 2) {
+                const errorMessage = 'Invalid message format, expected an array with 2 elements';
+                this.events.emit(SqsConsumerEvents.s3extendedPayloadError, {
+                    errorMessage,
+                    message: s3Object,
+                });
+                throw new Error(errorMessage);
+            }
+
+            const s3Key = msgJson[1]?.s3Key;
+            const s3BucketName = msgJson[1]?.s3BucketName;
+
+            if (!s3Key?.length || !s3BucketName?.length) {
+                const errorMessage = 'Invalid message format, s3Key and s3BucketName fields are required';
+                this.events.emit(SqsConsumerEvents.s3extendedPayloadError, {
+                    errorMessage,
+                    message: s3Object,
+                });
+                throw new Error(errorMessage);
+            }
+
             s3PayloadMeta = {
-                Bucket: msgJson.s3BucketName,
-                Key: msgJson.s3Key,
+                Bucket: s3BucketName,
+                Key: s3Key,
                 Id: 'not available in extended compatibility mode',
                 Location: 'not available in extended compatibility mode',
             };

--- a/src/sqs-producer.ts
+++ b/src/sqs-producer.ts
@@ -86,7 +86,7 @@ export class SqsProducer {
 
         if ((msgSize > this.messageSizeThreshold && this.largePayloadThoughS3) || this.allPayloadThoughS3) {
             const payloadId = uuid();
-            const payloadKey = `${payloadId}.json`;
+            const payloadKey = this.extendedLibraryCompatibility ? payloadId : `${payloadId}.json`;
             const s3Response = await this.s3
                 .upload({
                     Bucket: this.s3Bucket,
@@ -135,7 +135,7 @@ export class SqsProducer {
     // into another queue without duplicating the s3 object
     async sendS3Payload(
         s3PayloadMeta: S3PayloadMeta,
-        msgSize: number,
+        msgSize?: number,
         options: SqsMessageOptions = {}
     ): Promise<PromiseResult<aws.SQS.SendMessageResult, aws.AWSError>> {
         const messageAttributes = this.extendedLibraryCompatibility

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { AMAZON_EXTENDED_CLIENT_PAYLOAD_OFFLOADING_REFERENCE } from './constants';
+
 export interface PayloadMeta {
     S3Payload?: S3PayloadMeta;
 }
@@ -9,7 +11,9 @@ export interface S3PayloadMeta {
     Location: string;
 }
 
-export interface SqsExtendedPayloadMeta {
+export interface SqsExtendedPayloadS3Meta {
     s3BucketName: string;
     s3Key: string;
 }
+
+export type SqsExtendedPayloadMeta = [typeof AMAZON_EXTENDED_CLIENT_PAYLOAD_OFFLOADING_REFERENCE, SqsExtendedPayloadS3Meta];

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,6 @@
 import { MessageAttributeMap } from 'aws-sdk/clients/sns';
 import { S3PayloadMeta, PayloadMeta, SqsExtendedPayloadMeta } from './types';
-
-export const SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE = 'SQSLargePayloadSize';
+import { AMAZON_EXTENDED_CLIENT_PAYLOAD_OFFLOADING_REFERENCE, SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE } from './constants';
 
 export function createExtendedCompatibilityAttributeMap(msgSize: number): MessageAttributeMap {
     const result = {};
@@ -19,8 +18,9 @@ export function buildS3Payload(s3PayloadMeta: S3PayloadMeta): string {
 }
 
 export function buildS3PayloadWithExtendedCompatibility(s3PayloadMeta: S3PayloadMeta): string {
-    return JSON.stringify({
-        s3BucketName: s3PayloadMeta.Bucket,
-        s3Key: s3PayloadMeta.Key,
-    } as SqsExtendedPayloadMeta);
+    return JSON.stringify(
+        [AMAZON_EXTENDED_CLIENT_PAYLOAD_OFFLOADING_REFERENCE, {
+            s3BucketName: s3PayloadMeta.Bucket,
+            s3Key: s3PayloadMeta.Key,
+        }] as SqsExtendedPayloadMeta);
 }

--- a/tests/sns-sqs.spec.ts
+++ b/tests/sns-sqs.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../src';
 
 import * as aws from 'aws-sdk';
+import { v4 as uuid } from 'uuid';
 import { S3PayloadMeta } from '../src/types';
 
 // Real AWS services (for dev testing)
@@ -88,7 +89,7 @@ const getSqsProducer = (options: Partial<SqsProducerOptions> = {}) => {
     });
 };
 
-async function sendMessage(msg: any, options: Partial<SqsProducerOptions>) {
+async function sendMessage(msg: any, options?: Partial<SqsProducerOptions>) {
     const sqsProducer = getSqsProducer(options);
     return await sqsProducer.sendJSON(msg);
 }
@@ -96,6 +97,33 @@ async function sendMessage(msg: any, options: Partial<SqsProducerOptions>) {
 async function sendS3Payload(s3PayloadMeta: S3PayloadMeta, options: Partial<SqsProducerOptions>) {
     const sqsProducer = getSqsProducer(options);
     return await sqsProducer.sendS3Payload(s3PayloadMeta);
+}
+
+async function sendMessageInCompatibilityFormat(jsonBody: any, options: Partial<SqsProducerOptions>, generateMessageTemplate?: (s3BucketName: string, s3Key: string) => string) {
+    const s3ObjectKey = uuid();
+    const { s3, sqs } = getClients();
+    const s3Response = await s3.putObject({
+        Bucket: options.s3Bucket,
+        Key: s3ObjectKey,
+        Body: jsonBody,
+    }).promise();
+    const sqsResponse = await sqs
+        .sendMessage({
+            QueueUrl: options.queueUrl,
+            MessageBody: generateMessageTemplate ?
+                generateMessageTemplate(options.s3Bucket, s3ObjectKey) :
+                `["software.amazon.payloadoffloading.PayloadS3Pointer",{"s3BucketName":"${options.s3Bucket}","s3Key":"${s3ObjectKey}"}]`,
+            MessageAttributes: {
+                SQSLargePayloadSize: {
+                    StringValue: '5198',
+                    StringListValues: [],
+                    BinaryListValues: [],
+                    DataType: 'Number',
+                },
+            },
+        })
+        .promise();
+    return { s3Response, sqsResponse, s3ObjectKey };
 }
 
 const getSnsProducer = (options: Partial<SnsProducerOptions> = {}) => {
@@ -110,12 +138,12 @@ const getSnsProducer = (options: Partial<SnsProducerOptions> = {}) => {
     });
 };
 
-async function publishMessage(msg: any, options: Partial<SnsProducerOptions>) {
+async function publishMessage(msg: any, options?: Partial<SnsProducerOptions>) {
     const snsProducer = getSnsProducer(options);
     await snsProducer.publishJSON(msg);
 }
 
-async function publishS3Payload(s3PayloadMeta: S3PayloadMeta, options: Partial<SnsProducerOptions>) {
+async function publishS3Payload(s3PayloadMeta: S3PayloadMeta, options?: Partial<SnsProducerOptions>) {
     const snsProducer = getSnsProducer(options);
     await snsProducer.publishS3Payload(s3PayloadMeta);
 }
@@ -156,6 +184,12 @@ async function receiveMessages(
         });
 
         sqsConsumer.on(SqsConsumerEvents.processingError, () => {
+            sqsConsumer.stop();
+            clearTimeout(timeoutId);
+            resolve();
+        });
+
+        sqsConsumer.on(SqsConsumerEvents.s3extendedPayloadError, () => {
             sqsConsumer.stop();
             clearTimeout(timeoutId);
             resolve();
@@ -218,7 +252,7 @@ describe('sns-sqs-big-payload', () => {
                 await sendMessage(message);
                 const [receivedMessage] = await receiveMessages(1, {}, handlers);
                 // trigger macrotask to call event handlers
-                await new Promise((res) => setTimeout(res));
+                await new Promise((res) => setTimeout(res, undefined));
                 expect(receivedMessage.payload).toEqual(message);
 
                 // success
@@ -234,6 +268,7 @@ describe('sns-sqs-big-payload', () => {
                 expect(handlers[SqsConsumerEvents.processingError]).not.toBeCalled();
                 expect(handlers[SqsConsumerEvents.payloadParseError]).not.toBeCalled();
                 expect(handlers[SqsConsumerEvents.s3PayloadError]).not.toBeCalled();
+                expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).not.toBeCalled();
                 expect(handlers[SqsConsumerEvents.connectionError]).not.toBeCalled();
             });
 
@@ -259,6 +294,145 @@ describe('sns-sqs-big-payload', () => {
                 expect(handlers[SqsConsumerEvents.error]).not.toBeCalled();
                 expect(handlers[SqsConsumerEvents.connectionError]).not.toBeCalled();
                 expect(handlers[SqsConsumerEvents.payloadParseError]).not.toBeCalled();
+            });
+
+            describe('when processing the message format of AWS client lib', () => {
+                const handlers = getEventHandlers();
+                const processAWSClientLibMessage = async (generateMessageTemplate: (s3BucketName: string, s3Key: string) => string) => {
+                    const messageSizeThreshold = 1024;
+                    const message = 'x'.repeat(messageSizeThreshold + 1);
+                    const { s3ObjectKey } = await sendMessageInCompatibilityFormat(JSON.stringify(message), {
+                        largePayloadThoughS3: true,
+                        s3Bucket: TEST_BUCKET_NAME,
+                        queueUrl: testQueueUrl,
+                        messageSizeThreshold,
+                    }, generateMessageTemplate);
+
+                    await receiveMessages(1, {
+                        getPayloadFromS3: true,
+                        extendedLibraryCompatibility: true,
+                    }, handlers);
+                    return s3ObjectKey;
+                };
+
+                it('should not trigger s3extendedPayloadError event when the message is in correct format', async () => {
+                    await processAWSClientLibMessage(undefined);
+                    expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).not.toBeCalled();
+                });
+
+                it('should trigger s3extendedPayloadError event when the message is in unexpected format', async () => {
+                    const generateMessageTemplate = (s3BucketName: string, s3Key: string) =>
+                        `{"s3BucketName":"${s3BucketName}","s3Key":"${s3Key}"}`;
+                    const s3ObjectKey = await processAWSClientLibMessage(generateMessageTemplate);
+
+                    expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
+                        errorMessage: 'Invalid message format, expected an array with 2 elements',
+                        message: {
+                            s3BucketName: TEST_BUCKET_NAME,
+                            s3Key: s3ObjectKey,
+                        }
+                    });
+                });
+
+                it('should trigger s3extendedPayloadError event when the s3BucketName key in payload meta is missing', async () => {
+                    const generateMessageTemplate = (s3BucketName: string, s3Key: string) =>
+                        `["software.amazon.payloadoffloading.PayloadS3Pointer",{"s3Key":"${s3Key}"}]`;
+                    const s3ObjectKey = await processAWSClientLibMessage(generateMessageTemplate);
+
+                    expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
+                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        message: [
+                            "software.amazon.payloadoffloading.PayloadS3Pointer",
+                            {
+                                s3Key: s3ObjectKey,
+                            }
+                        ]
+                    });
+                });
+
+                it('should trigger s3extendedPayloadError event when the s3Key key in payload meta is missing', async () => {
+                    const generateMessageTemplate = (s3BucketName: string) =>
+                        `["software.amazon.payloadoffloading.PayloadS3Pointer",{"s3BucketName":"${s3BucketName}"}]`;
+                    await processAWSClientLibMessage(generateMessageTemplate);
+
+                    expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
+                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        message: [
+                            "software.amazon.payloadoffloading.PayloadS3Pointer",
+                            {
+                                s3BucketName: TEST_BUCKET_NAME,
+                            }
+                        ]
+                    });
+                });
+
+                it('should trigger s3extendedPayloadError event when the s3BucketName key in payload meta is faulty', async () => {
+                    const generateMessageTemplate = (s3BucketName: string, s3Key: string) =>
+                        `["software.amazon.payloadoffloading.PayloadS3Pointer",{"s3RandomBucketNameKey":"${s3BucketName}","s3Key":"${s3Key}"}]`;
+                    const s3ObjectKey = await processAWSClientLibMessage(generateMessageTemplate);
+
+                    expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
+                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        message: [
+                            "software.amazon.payloadoffloading.PayloadS3Pointer",
+                            {
+                                s3RandomBucketNameKey: TEST_BUCKET_NAME,
+                                s3Key: s3ObjectKey,
+                            }
+                        ]
+                    });
+                });
+
+                it('should trigger s3extendedPayloadError event when the s3Key key in payload meta is faulty', async () => {
+                    const generateMessageTemplate = (s3BucketName: string, s3Key: string) =>
+                        `["software.amazon.payloadoffloading.PayloadS3Pointer",{"s3BucketName":"${s3BucketName}","s3RandomObjectKey":"${s3Key}"}]`;
+                    const s3ObjectKey = await processAWSClientLibMessage(generateMessageTemplate);
+
+                    expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
+                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        message: [
+                            "software.amazon.payloadoffloading.PayloadS3Pointer",
+                            {
+                                s3BucketName: TEST_BUCKET_NAME,
+                                s3RandomObjectKey: s3ObjectKey,
+                            }
+                        ]
+                    });
+                });
+
+                it('should trigger s3extendedPayloadError event when the s3BucketName value in payload meta is empty', async () => {
+                    const generateMessageTemplate = (s3BucketName: string, s3Key: string) =>
+                        `["software.amazon.payloadoffloading.PayloadS3Pointer",{"s3BucketName":"","s3Key":"${s3Key}"}]`;
+                    const s3ObjectKey = await processAWSClientLibMessage(generateMessageTemplate);
+
+                    expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
+                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        message: [
+                            "software.amazon.payloadoffloading.PayloadS3Pointer",
+                            {
+                                s3BucketName: '',
+                                s3Key: s3ObjectKey,
+                            }
+                        ]
+                    });
+                });
+
+                it('should trigger s3extendedPayloadError event when the s3Key value in payload meta is empty', async () => {
+                    const generateMessageTemplate = (s3BucketName: string, s3Key: string) =>
+                        `["software.amazon.payloadoffloading.PayloadS3Pointer",{"s3BucketName":"${s3BucketName}","s3Key":""}]`;
+                    await processAWSClientLibMessage(generateMessageTemplate);
+
+                    expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
+                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        message: [
+                            "software.amazon.payloadoffloading.PayloadS3Pointer",
+                            {
+                                s3BucketName: TEST_BUCKET_NAME,
+                                s3Key: '',
+                            }
+                        ]
+                    });
+                });
             });
         });
 
@@ -292,39 +466,58 @@ describe('sns-sqs-big-payload', () => {
                 expect(receivedMessage.payload).toEqual(message);
             });
 
-            it('should send messages through s3 with extended compatibility mode', async () => {
-                const messageSizeThreshold = 512;
-                const message = 'x'.repeat(messageSizeThreshold + 1);
-                const { s3Response } = await sendMessage(message, {
-                    largePayloadThoughS3: true,
-                    s3Bucket: TEST_BUCKET_NAME,
-                    messageSizeThreshold,
-                    extendedLibraryCompatibility: true,
+            describe('with extended compatibility mode', () => {
+                it('should send messages through s3', async () => {
+                    const messageSizeThreshold = 512;
+                    const message = 'x'.repeat(messageSizeThreshold + 1);
+                    const { s3Response } = await sendMessage(message, {
+                        largePayloadThoughS3: true,
+                        s3Bucket: TEST_BUCKET_NAME,
+                        messageSizeThreshold,
+                        extendedLibraryCompatibility: true,
+                    });
+                    expect(s3Response).toBeDefined();
+                    const [receivedMessage] = await receiveMessages(1, {
+                        getPayloadFromS3: true,
+                        extendedLibraryCompatibility: true,
+                    });
+                    expect(receivedMessage.payload).toEqual(message);
                 });
-                expect(s3Response).toBeDefined();
-                const [receivedMessage] = await receiveMessages(1, {
-                    getPayloadFromS3: true,
-                    extendedLibraryCompatibility: true,
-                });
-                expect(receivedMessage.payload).toEqual(message);
-            });
 
-            it('should not send messages smaller than messageSizeThreshold through s3 with extended compatibility mode', async () => {
-                const messageSizeThreshold = 512;
-                const message = 'x'.repeat(messageSizeThreshold - 5);
-                const { s3Response } = await sendMessage(message, {
-                    largePayloadThoughS3: true,
-                    s3Bucket: TEST_BUCKET_NAME,
-                    messageSizeThreshold,
-                    extendedLibraryCompatibility: true,
+                it('should not send messages smaller than messageSizeThreshold through s3', async () => {
+                    const messageSizeThreshold = 512;
+                    const message = 'x'.repeat(messageSizeThreshold - 5);
+                    const { s3Response } = await sendMessage(message, {
+                        largePayloadThoughS3: true,
+                        s3Bucket: TEST_BUCKET_NAME,
+                        messageSizeThreshold,
+                        extendedLibraryCompatibility: true,
+                    });
+                    expect(s3Response).toBeUndefined();
+                    const [receivedMessage] = await receiveMessages(1, {
+                        getPayloadFromS3: true,
+                        extendedLibraryCompatibility: true,
+                    });
+                    expect(receivedMessage.payload).toEqual(message);
+                    expect(receivedMessage.s3PayloadMeta).toBeUndefined();
                 });
-                expect(s3Response).toBeUndefined();
-                const [receivedMessage] = await receiveMessages(1, {
-                    getPayloadFromS3: true,
-                    extendedLibraryCompatibility: true,
+
+                it('should be compatible with processing the message format of AWS client lib', async () => {
+                    const messageSizeThreshold = 1024;
+                    const message = 'x'.repeat(messageSizeThreshold + 1);
+                    const { sqsResponse: { MessageId } } = await sendMessageInCompatibilityFormat(JSON.stringify(message), {
+                        largePayloadThoughS3: true,
+                        s3Bucket: TEST_BUCKET_NAME,
+                        queueUrl: testQueueUrl,
+                        messageSizeThreshold,
+                    });
+                    expect(MessageId).toBeDefined();
+                    const [receivedMessage] = await receiveMessages(1, {
+                        getPayloadFromS3: true,
+                        extendedLibraryCompatibility: true,
+                    });
+                    expect(receivedMessage.payload).toEqual(message);
                 });
-                expect(receivedMessage.payload).toEqual(message);
-                expect(receivedMessage.s3PayloadMeta).toBeUndefined();
             });
 
             it('should send messages smaller than messageSizeThreshold as sqs payload', async () => {

--- a/tests/sns-sqs.spec.ts
+++ b/tests/sns-sqs.spec.ts
@@ -326,7 +326,7 @@ describe('sns-sqs-big-payload', () => {
                     const s3ObjectKey = await processAWSClientLibMessage(generateMessageTemplate);
 
                     expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
-                        errorMessage: 'Invalid message format, expected an array with 2 elements',
+                        err: new Error('Invalid message format, expected an array with 2 elements'),
                         message: {
                             s3BucketName: TEST_BUCKET_NAME,
                             s3Key: s3ObjectKey,
@@ -340,7 +340,7 @@ describe('sns-sqs-big-payload', () => {
                     const s3ObjectKey = await processAWSClientLibMessage(generateMessageTemplate);
 
                     expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
-                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        err: new Error('Invalid message format, s3Key and s3BucketName fields are required'),
                         message: [
                             "software.amazon.payloadoffloading.PayloadS3Pointer",
                             {
@@ -356,7 +356,7 @@ describe('sns-sqs-big-payload', () => {
                     await processAWSClientLibMessage(generateMessageTemplate);
 
                     expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
-                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        err: new Error('Invalid message format, s3Key and s3BucketName fields are required'),
                         message: [
                             "software.amazon.payloadoffloading.PayloadS3Pointer",
                             {
@@ -372,7 +372,7 @@ describe('sns-sqs-big-payload', () => {
                     const s3ObjectKey = await processAWSClientLibMessage(generateMessageTemplate);
 
                     expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
-                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        err: new Error('Invalid message format, s3Key and s3BucketName fields are required'),
                         message: [
                             "software.amazon.payloadoffloading.PayloadS3Pointer",
                             {
@@ -389,7 +389,7 @@ describe('sns-sqs-big-payload', () => {
                     const s3ObjectKey = await processAWSClientLibMessage(generateMessageTemplate);
 
                     expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
-                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        err: new Error('Invalid message format, s3Key and s3BucketName fields are required'),
                         message: [
                             "software.amazon.payloadoffloading.PayloadS3Pointer",
                             {
@@ -406,7 +406,7 @@ describe('sns-sqs-big-payload', () => {
                     const s3ObjectKey = await processAWSClientLibMessage(generateMessageTemplate);
 
                     expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
-                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        err: new Error('Invalid message format, s3Key and s3BucketName fields are required'),
                         message: [
                             "software.amazon.payloadoffloading.PayloadS3Pointer",
                             {
@@ -423,7 +423,7 @@ describe('sns-sqs-big-payload', () => {
                     await processAWSClientLibMessage(generateMessageTemplate);
 
                     expect(handlers[SqsConsumerEvents.s3extendedPayloadError]).toBeCalledWith({
-                        errorMessage: 'Invalid message format, s3Key and s3BucketName fields are required',
+                        err: new Error('Invalid message format, s3Key and s3BucketName fields are required'),
                         message: [
                             "software.amazon.payloadoffloading.PayloadS3Pointer",
                             {

--- a/tests/sns-sqs.spec.ts
+++ b/tests/sns-sqs.spec.ts
@@ -502,6 +502,28 @@ describe('sns-sqs-big-payload', () => {
                     expect(receivedMessage.s3PayloadMeta).toBeUndefined();
                 });
 
+                it('should produce messages in AWS client lib JSON format', async () => {
+                    const messageSizeThreshold = 1024;
+                    const message = 'x'.repeat(messageSizeThreshold + 1);
+                    const { s3Response } = await sendMessage(message, {
+                        largePayloadThoughS3: true,
+                        s3Bucket: TEST_BUCKET_NAME,
+                        messageSizeThreshold,
+                        extendedLibraryCompatibility: true,
+                    });
+                    const [receivedMessage] = await receiveMessages(1, {
+                        getPayloadFromS3: true,
+                        extendedLibraryCompatibility: true,
+                    });
+
+                    expect(JSON.parse(receivedMessage.message.Body)).toEqual(
+                        [
+                            "software.amazon.payloadoffloading.PayloadS3Pointer",
+                            {"s3BucketName":TEST_BUCKET_NAME,"s3Key":s3Response.Key}
+                        ]
+                    );
+                });
+
                 it('should be compatible with processing the message format of AWS client lib', async () => {
                     const messageSizeThreshold = 1024;
                     const message = 'x'.repeat(messageSizeThreshold + 1);


### PR DESCRIPTION
Fixes S3 reference in the message body not matching with the JSON schema of the Amazon SQS Java Extended Client library.

fixes #42 #19