### PR TITLE
Feature: Adds support for sqs message attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ await sqsProducer.sendJSON({
 });
 ```
 
+The sendJSON method of sqs producer also supports an optional sqs message options argument.
+
+```ts
+SqsMessageOptions {
+    DelaySeconds?: number;
+    MessageDeduplicationId?: string;
+    MessageGroupId?: string;
+    MessageAttributes?: MessageBodyAttributeMap;
+}
+```
+
 ### SQS Consumer
 
 ```ts

--- a/src/sqs-consumer.ts
+++ b/src/sqs-consumer.ts
@@ -128,7 +128,7 @@ export class SqsConsumer {
                     QueueUrl: this.queueUrl,
                     MaxNumberOfMessages: this.batchSize,
                     WaitTimeSeconds: this.waitTimeSeconds,
-                    MessageAttributeNames: [SQS_LARGE_PAYLOAD_SIZE_ATTRIBUTE],
+                    MessageAttributeNames: ['All'],
                 });
                 if (!this.started) return;
                 await this.handleSqsResponse(response);


### PR DESCRIPTION
This PR addresses the proposal which is mentioned in this [open issue](https://github.com/aspecto-io/sns-sqs-big-payload/issues/51).

**Note:** messageSystemAttributes isn't supported by the AWS SQS [receiveMessage method](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html) which we are using in the consumer service. So couldn't able to add it. But I think message attributes should be able to fulfill every requirement & we won't be needing messageSystemAttributes.